### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/mendeley/highlight_extract/doc.org
+++ b/mendeley/highlight_extract/doc.org
@@ -16,7 +16,7 @@ Not every document has a DOI, but most have. To get the list of doi
 SELECT doi FROM Documents;
 #+END_EXAMPLE
 
-http://dx.doi.org/ concatenate DOI of a paper to this url should get
+https://doi.org/ concatenate DOI of a paper to this url should get
 to the webpage of it.
 
 * Database

--- a/mendeley/paper_html_download/README.MD
+++ b/mendeley/paper_html_download/README.MD
@@ -25,7 +25,7 @@ option, the default output dir is `"html_output"`. If the file already
 exists, it will be skipped.
 
 There are two ways to retrieve web url for a paper, either
-automatically resolve the DOI of the paper from http://dx.doi.org, or
+automatically resolve the DOI of the paper from https://doi.org, or
 by extracting the url in mendeley database. In case of both are
 available, the preference will be determined by the `--prefer`
 argument.

--- a/mendeley/paper_html_download/webpage.py
+++ b/mendeley/paper_html_download/webpage.py
@@ -7,7 +7,7 @@ import os
 import argparse
 
 
-dxdoi = 'http://dx.doi.org/'
+dxdoi = 'https://doi.org/'
 
 
 def db_get_document_ids(cursor, group_name=''):


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update the code that generates new DOI links.

Cheers!